### PR TITLE
Fix: use numpy instead of predict_classes

### DIFF
--- a/chap1_colab/chap1_document.ipynb
+++ b/chap1_colab/chap1_document.ipynb
@@ -158,8 +158,11 @@
    "metadata": {},
    "source": [
     "```Python\n",
+    "import numpy as np\n",
+    "\n",
     "# 未知データを入力する（ここでは，評価に使ったx_testを入れる）\n",
-    "output = model.predict_classes(x_test[0:12])\n",
+    "predict_y=model.predict(x_test[0:12])\n",
+    "output=np.argmax(predict_y,axis=1)\n",
     "\n",
     "# 4つずつ出力\n",
     "for i,v in enumerate(output):\n",


### PR DESCRIPTION
tfのpredict_classesが消えていたので直してみました
ref: https://github.com/tensorflow/tensorflow/issues/52629